### PR TITLE
Fix guests listing for episode 122

### DIFF
--- a/classes/episodeguests.py
+++ b/classes/episodeguests.py
@@ -8,6 +8,7 @@ class EpisodeGuests:
     def clean_title(self):
         title_mappings = {
             'Uncle Bob': 'Uncle Bob + ',
+            '(feat. Uncle Bob)': 'Uncle Bob + '
             'Are You Garbage': 'Kevin James Ryan + Henry Foley',
             'Chad and JT': 'Chad Kroeger + JT Parr',
             'Howie Mandel meets The Family': 'Howie Mandel + Mom + Dad',


### PR DESCRIPTION
Related to #1

Updates the guest extraction logic in `classes/episodeguests.py` to correctly display all guests for episode 122.

- Adds a mapping for "(feat. Uncle Bob)" in `title_mappings` to ensure it is replaced correctly in the episode title, addressing the issue where Uncle Bob was not displayed properly.
- Maintains the existing logic for cleaning and parsing the episode title to extract guest names, ensuring compatibility with the format of episode 122 and other episodes.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zwitschi/tysoepisodeguide/issues/1?shareId=b3cdd5e2-2857-4b8c-97a7-2928ad1a7d22).